### PR TITLE
 handle stream errors

### DIFF
--- a/src/paging-stream.ts
+++ b/src/paging-stream.ts
@@ -32,22 +32,22 @@ export class PagingStream extends Readable {
     this._pageLimit = pageLimit;
   }
 
-  async _read () {
-    let response: any;
+  async _read() {
     try {
-      response = await this._loadPage(this._nextPageParams);
+      const response = await this._loadPage(this._nextPageParams);
       this._currPage++;
+
+
+      this._nextPageParams = this._getNextPageParams(response);
+
+      this._streamPage(response, this.push.bind(this));
+
+      if (!this._nextPageParams || this._currPage >= this._pageLimit) {
+        this.push(null);
+      }
     } catch (err) {
       this.destroy(err);
       return;
-    }
-
-    this._nextPageParams = this._getNextPageParams(response);
-
-    this._streamPage(response, this.push.bind(this));
-
-    if (!this._nextPageParams || this._currPage >= this._pageLimit) {
-      this.push(null);
     }
   }
 }


### PR DESCRIPTION
Similar to https://github.com/koopjs/koop-provider-hub-search/pull/58, this PR implements necessary error handling when streaming data from provider.

https://devtopia.esri.com/dc/hub/issues/10625