### PR TITLE
end ordered streams

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -108,7 +108,7 @@ export class HubApiModel {
         });
       });
     }
-    destination.emit('end');
+    destination.end(() => { });
   }
 
   private async getDomainRecord(portalUrl: string, siteUrl: string): Promise<IDomainEntry> {


### PR DESCRIPTION
This PR fixes an issue with sequenced node.js streams (when sort is applied) by using `passThrough.end(() => { })` to close streams instead of `passThrough.emit('end')`. This way ordered streams are properly closed instead of emitting the 'end' event without closing the stream. This prevents incomplete number of responses returned when sort is applied. CSV feed always applies sort by default and sometimes returning incomplete results.

https://devtopia.esri.com/dc/hub/issues/11772


