### PR TITLE
remove target from hubapi url

### DIFF
--- a/src/helpers/get-ogc-items-stream.test.ts
+++ b/src/helpers/get-ogc-items-stream.test.ts
@@ -126,43 +126,5 @@ describe('getOgcItemsStream function', () => {
     expect(axios.get).toBeCalledTimes(1);
     expect(axios.get).toHaveBeenNthCalledWith(1, 'https://my-site.hub.arcgis.com/api/search/v1/collections/all/items?limit=0&startindex=1');
   });
-
-  it('should target the given Hub API URL if specified', async () => {
-    // Setup
-    const siteUrl = 'https://my-site.hub.arcgis.com'
-    const ogcSearchRequestOpts = {
-      queryParams: {
-        limit: 150
-      },
-      collectionKey: 'all',
-      hubApiUrl: 'https://hubogctest.arcgis.com'
-    };
-    (axios.get as jest.Mock).mockResolvedValue({
-      data: {
-        numberMatched: 324,
-      }
-    });
-
-    // Test
-    const streams: PagingStream[] = await getOgcItemsStream(siteUrl, ogcSearchRequestOpts, hubsite);
-    expect(streams).toHaveLength(2);
-    expect(getPagingStreamSpy).toHaveBeenCalledTimes(2);
-    expect(getPagingStreamSpy).toHaveBeenNthCalledWith(
-      1,
-      'https://my-site.hub.arcgis.com/api/search/v1/collections/all/items?limit=100&startindex=1&target=hubogctest.arcgis.com',
-      hubsite,
-      1
-    );
-
-    expect(getPagingStreamSpy).toHaveBeenNthCalledWith(
-      2,
-      'https://my-site.hub.arcgis.com/api/search/v1/collections/all/items?limit=50&startindex=101&target=hubogctest.arcgis.com',
-      hubsite,
-      1
-    );
-
-    expect(axios.get).toBeCalledTimes(1);
-    expect(axios.get).toHaveBeenNthCalledWith(1, 'https://my-site.hub.arcgis.com/api/search/v1/collections/all/items?limit=0&startindex=1&target=hubogctest.arcgis.com');
-  });
 });
 

--- a/src/helpers/get-ogc-items-stream.ts
+++ b/src/helpers/get-ogc-items-stream.ts
@@ -37,11 +37,6 @@ const buildSearchRequestUrl = (siteUrl: string, ogcSearchRequestOpts: SearchRequ
   const searchRequest = _.cloneDeep(ogcSearchRequestOpts.queryParams);
   searchRequest.limit = Math.min(searchRequest.limit, MAX_LIMIT);
   searchRequest.startindex = searchRequest.startindex || 1;
-
-  if (ogcSearchRequestOpts.hubApiUrl) {
-    searchRequest.target = getDomainFromUrl(ogcSearchRequestOpts.hubApiUrl);
-  }
-
   const searchParams = new URLSearchParams(searchRequest).toString();
   return `${siteUrl}/api/search/v1/collections/${ogcSearchRequestOpts.collectionKey}/items?${searchParams}`;
 };
@@ -50,11 +45,6 @@ const getTotalCount = async (siteUrl: string, ogcSearchRequestOpts: SearchReques
   const searchRequest = _.cloneDeep(ogcSearchRequestOpts.queryParams);
   searchRequest.limit = 0;
   searchRequest.startindex = 1;
-
-  if (ogcSearchRequestOpts.hubApiUrl) {
-    searchRequest.target = getDomainFromUrl(ogcSearchRequestOpts.hubApiUrl);
-  }
-
   const searchParams = new URLSearchParams(searchRequest).toString();
   const fetchUrl = `${siteUrl}/api/search/v1/collections/${ogcSearchRequestOpts.collectionKey}/items?${searchParams}`;
   const res = await axios.get(fetchUrl);
@@ -69,16 +59,3 @@ const getTotalCount = async (siteUrl: string, ogcSearchRequestOpts: SearchReques
 const getPagesPerBatch = (limit: number, requestIndex: number, requests: any, pagesPerBatch: number) => {
   return limit ? (requestIndex + 1 === requests.length ? 1 : pagesPerBatch) : pagesPerBatch;
 };
-
-function getDomainFromUrl(url: string): string {
-  try {
-    // Check if the URL is a domain-only string
-    if (!url.startsWith('http://') && !url.startsWith('https://')) {
-      url = `http://${url}`;
-    }
-    const parsedUrl = new URL(url);
-    return parsedUrl.hostname;
-  } catch (error) {
-    throw new Error(`Invalid Hub API URL: ${url}`);
-  }
-}


### PR DESCRIPTION
Hub search API's `target` query is used to target specific host and not hub wide API URL. Previously, I assumed hub API URL to site hostname. This PR corrects the issue.

Hub feeds API will ensure search is executed using regional search service by using `target` param in E2E.