### PR TITLE
B/12639 hub feeds error

### DIFF
--- a/src/helpers/enrich-dataset.test.ts
+++ b/src/helpers/enrich-dataset.test.ts
@@ -317,7 +317,7 @@ describe('enrichDataset function', () => {
         expect(properties.accessUrlWFS).toBe('https://sampleserver3.arcgisonline.com/arcgis/services/Earthquakes/RecentEarthquakesRendered/MapServer/WFSServer?request=GetCapabilities&service=WFS');
     });
 
-    it('should not generate WFS distribution access url if WFSServer is supported extension but does not have an url', () => {
+    it('should NOT generate WFS distribution access url if WFSServer is supported extension but does not have an url', () => {
         const hubDataset = {
             id: 'foo',
             access: 'public',
@@ -361,7 +361,7 @@ describe('enrichDataset function', () => {
         expect(properties.accessUrlWMS).toBe('https://sampleserver3.arcgisonline.com/arcgis/services/Earthquakes/RecentEarthquakesRendered/MapServer/WMSServer?request=GetCapabilities&service=WMS');
     });
 
-    it('should generate WMS distribution url if WMSServer is supported extension but does not have an url', () => {
+    it('should NOT generate WMS distribution url if WMSServer is supported extension but does not have an url', () => {
         const hubDataset = {
             id: 'foo',
             access: 'public',

--- a/src/helpers/enrich-dataset.test.ts
+++ b/src/helpers/enrich-dataset.test.ts
@@ -295,7 +295,7 @@ describe('enrichDataset function', () => {
         expect(properties.license).toBe(null);
     });
 
-    it('should generate WFS distribution url if supported', () => {
+    it('should generate WFS distribution url if supported and has url', () => {
         const hubDataset = {
             id: 'foo',
             access: 'public',
@@ -317,7 +317,7 @@ describe('enrichDataset function', () => {
         expect(properties.accessUrlWFS).toBe('https://sampleserver3.arcgisonline.com/arcgis/services/Earthquakes/RecentEarthquakesRendered/MapServer/WFSServer?request=GetCapabilities&service=WFS');
     });
 
-    it('should generate WMS distribution url if supported', () => {
+    it('should generate WMS distribution url if supported and has url', () => {
         const hubDataset = {
             id: 'foo',
             access: 'public',

--- a/src/helpers/enrich-dataset.test.ts
+++ b/src/helpers/enrich-dataset.test.ts
@@ -295,7 +295,7 @@ describe('enrichDataset function', () => {
         expect(properties.license).toBe(null);
     });
 
-    it('should generate WFS distribution url if supported and has url', () => {
+    it('should generate WFS distribution if WFSServer is supported extension and has url', () => {
         const hubDataset = {
             id: 'foo',
             access: 'public',
@@ -317,7 +317,29 @@ describe('enrichDataset function', () => {
         expect(properties.accessUrlWFS).toBe('https://sampleserver3.arcgisonline.com/arcgis/services/Earthquakes/RecentEarthquakesRendered/MapServer/WFSServer?request=GetCapabilities&service=WFS');
     });
 
-    it('should generate WMS distribution url if supported and has url', () => {
+    it('should not generate WFS distribution access url if WFSServer is supported extension but does not have an url', () => {
+        const hubDataset = {
+            id: 'foo',
+            access: 'public',
+            slug: 'nissan::skyline-gtr',
+            size: 1,
+            type: 'CSV',
+            created: 1570747289000,
+            license: 'none',
+            supportedExtensions: ['WFSServer'],
+            url: undefined,
+        };
+
+        const geojson = {
+            type: 'Feature',
+            properties: hubDataset
+        }
+
+        const { properties } = enrichDataset(geojson, hubsite);
+        expect(properties.accessUrlWFS).toBeUndefined();
+    });
+
+    it('should generate WMS distribution url if WMSServer is supported extension and has url', () => {
         const hubDataset = {
             id: 'foo',
             access: 'public',
@@ -337,6 +359,28 @@ describe('enrichDataset function', () => {
 
         const { properties } = enrichDataset(geojson, hubsite);
         expect(properties.accessUrlWMS).toBe('https://sampleserver3.arcgisonline.com/arcgis/services/Earthquakes/RecentEarthquakesRendered/MapServer/WMSServer?request=GetCapabilities&service=WMS');
+    });
+
+    it('should generate WMS distribution url if WMSServer is supported extension but does not have an url', () => {
+        const hubDataset = {
+            id: 'foo',
+            access: 'public',
+            slug: 'nissan::skyline-gtr',
+            size: 1,
+            type: 'CSV',
+            created: 1570747289000,
+            license: 'none',
+            supportedExtensions: ['WMSServer'],
+            url: undefined,
+        };
+
+        const geojson = {
+            type: 'Feature',
+            properties: hubDataset
+        }
+
+        const { properties } = enrichDataset(geojson, hubsite);
+        expect(properties.accessUrlWMS).toBeUndefined();
     });
 
     it('should generate download link without query string if wkid is not present in spatialReference', () => {

--- a/src/helpers/enrich-dataset.ts
+++ b/src/helpers/enrich-dataset.ts
@@ -58,11 +58,11 @@ export function enrichDataset(dataset: Record<string, any>, siteDetails: Record<
         }
     }
 
-    if (datasetAttr.supportedExtensions?.includes(WFS_SERVER)) {
+    if (datasetAttr.supportedExtensions?.includes(WFS_SERVER) && !_.isNil(datasetAttr.url)) {
         additionalFields.accessUrlWFS = ogcUrl(datasetAttr.url, 'WFS');
     }
 
-    if (datasetAttr.supportedExtensions?.includes(WMS_SERVER)) {
+    if (datasetAttr.supportedExtensions?.includes(WMS_SERVER) && !_.isNil(datasetAttr.url)) {
         additionalFields.accessUrlWMS = ogcUrl(datasetAttr.url, 'WMS');
     }
 


### PR DESCRIPTION
Sometimes dataset's url might not be indexed when its server cannot be reached and compose job fails (example dataset [here](https://geohub.lio.gov.on.ca/api/search/v1/collections/all/items?limit=10&id=0373c5f4bdeb49f29296dccb66b7e04f_3&flatten=true&fields=url&startindex=1) and its [server](https://ws.lioservices.lrc.gov.on.ca/arcgis1071a/rest/services/LIO_OPEN_DATA/LIO_Open10/MapServer/3) which is unreachable). Provider expected dataset's url to be always present causing the bug like [this](https://devtopia.esri.com/dc/hub/issues/12639). When a dataset's url is missing, feed returns error when rendering feed because provider is trying to access an `undefined` property. This PR fixes the issue by constructing distribution url only if dataset has url defined.

https://devtopia.esri.com/dc/hub/issues/12639
